### PR TITLE
Removed config blocks that weren't doing anything.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,19 +25,12 @@ end
   end
 end
 
-configure :production do
-  host = ENV['HOST'] || 'permafrast.herokuapp.com'
-  
-  set :host, host
-  set :force_ssl, true
-end
-
-before(/.*/) do
-  if request.url.match(/.json$/)
-    request.accept.unshift('application/json')
-    request.path_info = request.path_info.gsub(/.json$/,'')
-  end
-end
+#configure :production do
+#  host = ENV['HOST'] || 'permafrast.herokuapp.com'
+ 
+#  set :host, host
+#  set :force_ssl, true
+#end
 
 class App < Sinatra::Base
   register Sinatra::Contrib


### PR DESCRIPTION
The `before` block originally handled json requests.
By moving the app into a class, and leaving the before block
outside of that class, we briefly lost that functionality.
It has since been reimplemented by other mean.

I'm currently removing the force_ssl block. This should,
and will, be addressed by a different commit.
