### PR TITLE
Refactored calls to Cacher with a one-liner

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,13 +50,9 @@ class App < Sinatra::Base
   
   get '/:vol/:reporter/:page.json' do
     content_type :json
-
-    data = Cacher.new(
-      volume: params["vol"],
-      reporter: params["reporter"],
-      page: params["page"]
-    ).cache!
     
+    data = Cacher.cache_with_params!(params)
+
     keys = [
       :volume,
       :reporter,
@@ -75,22 +71,14 @@ class App < Sinatra::Base
   end
 
   get '/:vol/:reporter/:page' do
-    data = Cacher.new(
-      volume: params["vol"],
-      reporter: params["reporter"],
-      page: params["page"]
-    ).cache!
-
+    data = Cacher.cache_with_params!(params)
+  
     erb :app, :locals => {"out"=>data}
   end
 
   get '/:vol/:reporter/:page/redirect' do
-    data = Cacher.new(
-      volume: params["vol"],
-      reporter: params["reporter"],
-      page: params["page"]
-    ).cache!
-
+    data = Cacher.cache_with_params!(params)
+    
     redirect data.url
   end
 

--- a/use_cases/cacher.rb
+++ b/use_cases/cacher.rb
@@ -8,6 +8,14 @@ class Cacher
   end
 
   attr_accessor :volume, :reporter, :page, :cached_entry
+  
+  def self.cache_with_params!(params)
+    Cacher.new(
+      volume: params["vol"],
+      reporter: params["reporter"],
+      page: params["page"]
+    ).cache!
+  end
 
   def cache!
     if cached_record && cached_record.fetched_page.present?


### PR DESCRIPTION
``` ruby
get '/:vol/:reporter/:page.json' do
  data = Cacher.cache_with_params!(params)
  # ...
end
```
